### PR TITLE
Relax `HtmlAttributes` factory requirements

### DIFF
--- a/src/Plugin/Factory/HtmlAttributesFactory.php
+++ b/src/Plugin/Factory/HtmlAttributesFactory.php
@@ -12,6 +12,10 @@ final class HtmlAttributesFactory
 {
     public function __invoke(ContainerInterface $container): HtmlAttributes
     {
-        return new HtmlAttributes($container->get(Escaper::class));
+        return new HtmlAttributes(
+            $container->has(Escaper::class)
+            ? $container->get(Escaper::class)
+            : new Escaper(),
+        );
     }
 }

--- a/test/Plugin/Factory/HtmlAttributesFactoryTest.php
+++ b/test/Plugin/Factory/HtmlAttributesFactoryTest.php
@@ -12,6 +12,12 @@ use PHPUnit\Framework\TestCase;
 
 class HtmlAttributesFactoryTest extends TestCase
 {
+    public function testPluginCanBeRetrievedWithZeroConfig(): void
+    {
+        $plugin = (new HtmlAttributesFactory())->__invoke(new InMemoryContainer());
+        self::assertInstanceOf(HtmlAttributes::class, $plugin);
+    }
+
     public function testPluginCanBeRetrievedWhenTheEscaperIsAlsoAvailable(): void
     {
         $plugin = (new HtmlAttributesFactory())->__invoke(new InMemoryContainer([


### PR DESCRIPTION
Allow the HtmlAttributes plugin to be retrieved from the container when no escaper is available.