### PR TITLE
Plugin State Management Design Fixes

### DIFF
--- a/src/PluginManager.php
+++ b/src/PluginManager.php
@@ -4,8 +4,18 @@ declare(strict_types=1);
 
 namespace Looker;
 
+use Looker\Renderer\RenderingFailed;
 use Psr\Container\ContainerInterface;
 
 interface PluginManager extends ContainerInterface
 {
+    public function clearPluginState(): void;
+
+    /**
+     * @param non-empty-string $method
+     * @param array<string, mixed> $args
+     *
+     * @throws RenderingFailed If plugin retrieval or execution causes any exception.
+     */
+    public function __call(string $method, array $args): mixed;
 }

--- a/src/Renderer/PhpRenderer.php
+++ b/src/Renderer/PhpRenderer.php
@@ -5,49 +5,28 @@ declare(strict_types=1);
 namespace Looker\Renderer;
 
 use Looker\Model\ViewModel;
-use Looker\Plugin\StatefulPlugin;
 use Looker\Template\Resolver;
 use Looker\Template\TemplateCannotBeResolved;
 use Psr\Container\ContainerInterface;
 
 final readonly class PhpRenderer implements Renderer
 {
+    private PluginProxy $pluginProxy;
+
     public function __construct(
         private Resolver $resolver,
         private ContainerInterface $plugins,
         private bool $strictVariables = true,
         private bool $passScopeToChildren = false,
     ) {
-    }
-
-    public function render(ViewModel $model): string
-    {
-        $pluginProxy = new PluginProxy($this->plugins);
-
-        $content = $this->renderModel($model, $pluginProxy);
-
-        /**
-         * After rendering, clear the state of any stateful plugins called
-         */
-        foreach ($pluginProxy->calledPlugins() as $alias) {
-            $plugin = $this->plugins->get($alias);
-            if (! $plugin instanceof StatefulPlugin) {
-                continue;
-            }
-
-            $plugin->resetState();
-        }
-
-        // Maybe apply post rendering filter?
-
-        return $content;
+        $this->pluginProxy = new PluginProxy($this->plugins);
     }
 
     /**
      * @throws RenderingFailed
      * @throws TemplateCannotBeResolved
      */
-    private function renderModel(ViewModel $model, PluginProxy $proxy): string
+    public function render(ViewModel $model): string
     {
         foreach ($model->childModels() as $child) {
             $childModel = $child->model;
@@ -55,11 +34,16 @@ final readonly class PhpRenderer implements Renderer
                 $childModel = $childModel->mergeRetain($model->variables());
             }
 
-            $model = $model->withVariable($child->captureTo, $this->renderModel($childModel, $proxy));
+            $model = $model->withVariable($child->captureTo, $this->render($childModel));
         }
 
         $file = $this->resolver->resolve($model->template());
 
-        return (new Target($file, $model->variables(), $proxy, $this->strictVariables))();
+        return (new Target($file, $model->variables(), $this->pluginProxy, $this->strictVariables))();
+    }
+
+    public function clearPluginState(): void
+    {
+        $this->pluginProxy->clearPluginState();
     }
 }

--- a/src/Renderer/PhpRenderer.php
+++ b/src/Renderer/PhpRenderer.php
@@ -5,21 +5,18 @@ declare(strict_types=1);
 namespace Looker\Renderer;
 
 use Looker\Model\ViewModel;
+use Looker\PluginManager;
 use Looker\Template\Resolver;
 use Looker\Template\TemplateCannotBeResolved;
-use Psr\Container\ContainerInterface;
 
 final readonly class PhpRenderer implements Renderer
 {
-    private PluginProxy $pluginProxy;
-
     public function __construct(
         private Resolver $resolver,
-        private ContainerInterface $plugins,
+        private PluginManager $plugins,
         private bool $strictVariables = true,
         private bool $passScopeToChildren = false,
     ) {
-        $this->pluginProxy = new PluginProxy($this->plugins);
     }
 
     /**
@@ -39,11 +36,6 @@ final readonly class PhpRenderer implements Renderer
 
         $file = $this->resolver->resolve($model->template());
 
-        return (new Target($file, $model->variables(), $this->pluginProxy, $this->strictVariables))();
-    }
-
-    public function clearPluginState(): void
-    {
-        $this->pluginProxy->clearPluginState();
+        return (new Target($file, $model->variables(), $this->plugins, $this->strictVariables))();
     }
 }

--- a/src/Renderer/PluginProxy.php
+++ b/src/Renderer/PluginProxy.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Looker\Renderer;
 
 use Looker\Plugin\StatefulPlugin;
+use Looker\PluginManager;
 use Psr\Container\ContainerInterface;
 use Throwable;
 
@@ -12,7 +13,7 @@ use function array_keys;
 use function is_callable;
 
 /** @internal */
-final class PluginProxy
+final class PluginProxy implements PluginManager
 {
     /** @var array<string, null> */
     private array $called = [];
@@ -23,19 +24,40 @@ final class PluginProxy
     }
 
     /**
+     * @param non-empty-string $id
+     *
+     * @return callable
+     *
+     * @throws RenderingFailed If the plugin cannot be found, or, if the plugin is not callable.
+     */
+    public function get(string $id): mixed
+    {
+        if (! $this->pluginContainer->has($id)) {
+            throw RenderingFailed::becauseAPluginDoesNotExist($id);
+        }
+
+        $plugin = $this->pluginContainer->get($id);
+        if (! is_callable($plugin)) {
+            throw RenderingFailed::becauseAPluginIsNotInvokable($id, $plugin);
+        }
+
+        return $plugin;
+    }
+
+    public function has(string $id): bool
+    {
+        return $this->pluginContainer->has($id);
+    }
+
+    /**
      * @param non-empty-string $method
      * @param array<string, mixed> $args
+     *
+     * @throws RenderingFailed If any exceptions occur during plugin retrieval or execution.
      */
     public function __call(string $method, array $args): mixed
     {
-        if (! $this->pluginContainer->has($method)) {
-            throw RenderingFailed::becauseAPluginDoesNotExist($method);
-        }
-
-        $plugin = $this->pluginContainer->get($method);
-        if (! is_callable($plugin)) {
-            throw RenderingFailed::becauseAPluginIsNotInvokable($method, $plugin);
-        }
+        $plugin = $this->get($method);
 
         try {
             /** @psalm-var mixed $returnValue */

--- a/src/Renderer/PluginProxy.php
+++ b/src/Renderer/PluginProxy.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Looker\Renderer;
 
+use Looker\Plugin\StatefulPlugin;
 use Psr\Container\ContainerInterface;
 use Throwable;
 
@@ -47,9 +48,17 @@ final class PluginProxy
         }
     }
 
-    /** @return list<string> */
-    public function calledPlugins(): array
+    public function clearPluginState(): void
     {
-        return array_keys($this->called);
+        foreach (array_keys($this->called) as $name) {
+            $plugin = $this->pluginContainer->get($name);
+            if (! $plugin instanceof StatefulPlugin) {
+                continue;
+            }
+
+            $plugin->resetState();
+        }
+
+        $this->called = [];
     }
 }

--- a/src/Renderer/PluginProxy.php
+++ b/src/Renderer/PluginProxy.php
@@ -29,6 +29,8 @@ final class PluginProxy implements PluginManager
      * @return callable
      *
      * @throws RenderingFailed If the plugin cannot be found, or, if the plugin is not callable.
+     *
+     * @psalm-suppress MethodSignatureMismatch - No it's not
      */
     public function get(string $id): mixed
     {

--- a/src/Renderer/Renderer.php
+++ b/src/Renderer/Renderer.php
@@ -10,6 +10,4 @@ interface Renderer
 {
     /** @throws RenderingFailed */
     public function render(ViewModel $model): string;
-
-    public function clearPluginState(): void;
 }

--- a/src/Renderer/Renderer.php
+++ b/src/Renderer/Renderer.php
@@ -10,4 +10,6 @@ interface Renderer
 {
     /** @throws RenderingFailed */
     public function render(ViewModel $model): string;
+
+    public function clearPluginState(): void;
 }

--- a/src/Renderer/Target.php
+++ b/src/Renderer/Target.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Looker\Renderer;
 
+use Looker\PluginManager;
 use Throwable;
 
 use function array_key_exists;
@@ -27,7 +28,7 @@ final class Target
     public function __construct(
         private readonly string $__template,
         private readonly array $__variables,
-        private readonly PluginProxy $__plugins,
+        private readonly PluginManager $__plugins,
         private readonly bool $__strictVariables = true,
     ) {
     }

--- a/src/View.php
+++ b/src/View.php
@@ -21,6 +21,7 @@ final readonly class View
      */
     public function __construct(
         private Renderer $renderer,
+        private PluginManager $plugins,
         private string|null $defaultLayout = null,
         private string $captureTo = 'content',
     ) {
@@ -54,7 +55,7 @@ final readonly class View
             );
         }
 
-        $this->renderer->clearPluginState();
+        $this->plugins->clearPluginState();
 
         return $buffer;
     }

--- a/src/View.php
+++ b/src/View.php
@@ -46,13 +46,17 @@ final readonly class View
 
         $layout = $this->resolveLayout($viewModel);
         if ($layout === false) {
-            return $this->renderer->render($viewModel);
+            $buffer = $this->renderer->render($viewModel);
+        } else {
+            $buffer = $this->renderer->render(
+                Model::terminal($layout)
+                    ->withChild($viewModel, $this->captureTo),
+            );
         }
 
-        return $this->renderer->render(
-            Model::terminal($layout)
-                ->withChild($viewModel, $this->captureTo),
-        );
+        $this->renderer->clearPluginState();
+
+        return $buffer;
     }
 
     /** @return non-empty-string|false */

--- a/test/Integration/NestedModel/NestedModelTest.php
+++ b/test/Integration/NestedModel/NestedModelTest.php
@@ -6,6 +6,7 @@ namespace Looker\Test\Integration\NestedModel;
 
 use Looker\Model\Model;
 use Looker\Renderer\PhpRenderer;
+use Looker\Renderer\PluginProxy;
 use Looker\Template\MapResolver;
 use Looker\Test\InMemoryContainer;
 use PHPUnit\Framework\TestCase;
@@ -24,7 +25,7 @@ final class NestedModelTest extends TestCase
                 't2' => __DIR__ . '/templates/level2.phtml',
                 't3' => __DIR__ . '/templates/level3.phtml',
             ]),
-            new InMemoryContainer(),
+            new PluginProxy(new InMemoryContainer()),
             true,
             false,
         );

--- a/test/Integration/ParentToChildScope/ParentToChildScopeTest.php
+++ b/test/Integration/ParentToChildScope/ParentToChildScopeTest.php
@@ -6,6 +6,7 @@ namespace Looker\Test\Integration\ParentToChildScope;
 
 use Looker\Model\Model;
 use Looker\Renderer\PhpRenderer;
+use Looker\Renderer\PluginProxy;
 use Looker\Template\MapResolver;
 use Looker\Test\InMemoryContainer;
 use PHPUnit\Framework\TestCase;
@@ -38,7 +39,7 @@ final class ParentToChildScopeTest extends TestCase
 
         $renderer = new PhpRenderer(
             $this->resolver,
-            new InMemoryContainer(),
+            new PluginProxy(new InMemoryContainer()),
             true,
             true,
         );

--- a/test/Integration/ResetPluginState/PluginResetTest.php
+++ b/test/Integration/ResetPluginState/PluginResetTest.php
@@ -6,6 +6,7 @@ namespace Looker\Test\Integration\ResetPluginState;
 
 use Looker\Model\Model;
 use Looker\Renderer\PhpRenderer;
+use Looker\Renderer\PluginProxy;
 use Looker\Template\MapResolver;
 use Looker\Test\InMemoryContainer;
 use Looker\Test\Renderer\Plugins\Stateful;
@@ -30,15 +31,17 @@ final class PluginResetTest extends TestCase
     public function testThatStatefulPluginsAreReset(): void
     {
         $plugin = new Stateful();
+        $plugins = new PluginProxy(new InMemoryContainer(['plugin' => $plugin]));
         $renderer = new View(
             new PhpRenderer(
                 new MapResolver([
                     'template' => __DIR__ . '/templates/stateful-plugin.phtml',
                 ]),
-                new InMemoryContainer(['plugin' => $plugin]),
+                $plugins,
                 true,
                 false,
             ),
+            $plugins,
         );
 
         $result = $renderer->render(Model::new('template'));
@@ -50,20 +53,22 @@ final class PluginResetTest extends TestCase
     public function testThatNonStatefulPluginsAreNotReset(): void
     {
         $plugin = new Stateful();
+        $plugins = new PluginProxy(new InMemoryContainer([
+            'plugin' => $plugin,
+            'other' => static function (): string {
+                return PHP_EOL . 'Hey!';
+            },
+        ]));
         $renderer = new View(
             new PhpRenderer(
                 new MapResolver([
                     'template' => __DIR__ . '/templates/mixed.phtml',
                 ]),
-                new InMemoryContainer([
-                    'plugin' => $plugin,
-                    'other' => static function (): string {
-                        return PHP_EOL . 'Hey!';
-                    },
-                ]),
+                $plugins,
                 true,
                 false,
             ),
+            $plugins,
         );
 
         $result = $renderer->render(Model::new('template'));

--- a/test/Integration/ResetPluginState/PluginResetTest.php
+++ b/test/Integration/ResetPluginState/PluginResetTest.php
@@ -8,7 +8,8 @@ use Looker\Model\Model;
 use Looker\Renderer\PhpRenderer;
 use Looker\Template\MapResolver;
 use Looker\Test\InMemoryContainer;
-use Looker\Test\Integration\ResetPluginState\Plugins\Stateful;
+use Looker\Test\Renderer\Plugins\Stateful;
+use Looker\View;
 use PHPUnit\Framework\TestCase;
 
 use const PHP_EOL;
@@ -29,13 +30,15 @@ final class PluginResetTest extends TestCase
     public function testThatStatefulPluginsAreReset(): void
     {
         $plugin = new Stateful();
-        $renderer = new PhpRenderer(
-            new MapResolver([
-                'template' => __DIR__ . '/templates/stateful-plugin.phtml',
-            ]),
-            new InMemoryContainer(['plugin' => $plugin]),
-            true,
-            false,
+        $renderer = new View(
+            new PhpRenderer(
+                new MapResolver([
+                    'template' => __DIR__ . '/templates/stateful-plugin.phtml',
+                ]),
+                new InMemoryContainer(['plugin' => $plugin]),
+                true,
+                false,
+            ),
         );
 
         $result = $renderer->render(Model::new('template'));
@@ -47,18 +50,20 @@ final class PluginResetTest extends TestCase
     public function testThatNonStatefulPluginsAreNotReset(): void
     {
         $plugin = new Stateful();
-        $renderer = new PhpRenderer(
-            new MapResolver([
-                'template' => __DIR__ . '/templates/mixed.phtml',
-            ]),
-            new InMemoryContainer([
-                'plugin' => $plugin,
-                'other' => static function (): string {
-                    return PHP_EOL . 'Hey!';
-                },
-            ]),
-            true,
-            false,
+        $renderer = new View(
+            new PhpRenderer(
+                new MapResolver([
+                    'template' => __DIR__ . '/templates/mixed.phtml',
+                ]),
+                new InMemoryContainer([
+                    'plugin' => $plugin,
+                    'other' => static function (): string {
+                        return PHP_EOL . 'Hey!';
+                    },
+                ]),
+                true,
+                false,
+            ),
         );
 
         $result = $renderer->render(Model::new('template'));

--- a/test/Integration/ViewLayout/ViewLayoutTest.php
+++ b/test/Integration/ViewLayout/ViewLayoutTest.php
@@ -6,6 +6,7 @@ namespace Looker\Test\Integration\ViewLayout;
 
 use Looker\Model\Model;
 use Looker\Renderer\PhpRenderer;
+use Looker\Renderer\PluginProxy;
 use Looker\Renderer\RenderingFailed;
 use Looker\Template\MapResolver;
 use Looker\Test\InMemoryContainer;
@@ -16,16 +17,18 @@ final class ViewLayoutTest extends TestCase
 {
     public function testThatTheDefaultLayoutIsRenderedWhenGivenAnArrayAndContentTemplate(): void
     {
+        $plugins = new PluginProxy(new InMemoryContainer([]));
         $view = new View(
             new PhpRenderer(
                 new MapResolver([
                     'layout-template' => __DIR__ . '/templates/layout.phtml',
                     'content-template' => __DIR__ . '/templates/content.phtml',
                 ]),
-                new InMemoryContainer([]),
+                $plugins,
                 true,
                 false,
             ),
+            $plugins,
             'layout-template',
             'content',
         );
@@ -46,15 +49,17 @@ final class ViewLayoutTest extends TestCase
 
     public function testThatWhenThereIsNoDefaultLayoutAndTheViewDoesNotSpecifyThenNoLayoutWillBeUsed(): void
     {
+        $plugins = new PluginProxy(new InMemoryContainer([]));
         $view = new View(
             new PhpRenderer(
                 new MapResolver([
                     'content-template' => __DIR__ . '/templates/content.phtml',
                 ]),
-                new InMemoryContainer([]),
+                $plugins,
                 true,
                 false,
             ),
+            $plugins,
         );
 
         $content = $view->render(['title' => 'Hello World'], 'content-template');
@@ -70,16 +75,18 @@ final class ViewLayoutTest extends TestCase
 
     public function testThatWhenTheViewExplicitlyDisablesTheLayoutThenNoLayoutWillBeUsed(): void
     {
+        $plugins = new PluginProxy(new InMemoryContainer([]));
         $view = new View(
             new PhpRenderer(
                 new MapResolver([
                     'layout-template' => __DIR__ . '/templates/layout.phtml',
                     'content-template' => __DIR__ . '/templates/content.phtml',
                 ]),
-                new InMemoryContainer([]),
+                $plugins,
                 true,
                 false,
             ),
+            $plugins,
             'layout-template',
             'content',
         );
@@ -97,6 +104,7 @@ final class ViewLayoutTest extends TestCase
 
     public function testThatWhenTheViewDeclaresAlternativeLayoutThenItWillBeUsed(): void
     {
+        $plugins = new PluginProxy(new InMemoryContainer([]));
         $view = new View(
             new PhpRenderer(
                 new MapResolver([
@@ -104,10 +112,11 @@ final class ViewLayoutTest extends TestCase
                     'layout-template' => __DIR__ . '/templates/layout.phtml',
                     'content-template' => __DIR__ . '/templates/content.phtml',
                 ]),
-                new InMemoryContainer([]),
+                $plugins,
                 true,
                 false,
             ),
+            $plugins,
             'layout-template',
             'content',
         );
@@ -127,15 +136,17 @@ final class ViewLayoutTest extends TestCase
 
     public function testThatAViewModelIsAcceptableToRender(): void
     {
+        $plugins = new PluginProxy(new InMemoryContainer([]));
         $view = new View(
             new PhpRenderer(
                 new MapResolver([
                     'content-template' => __DIR__ . '/templates/content.phtml',
                 ]),
-                new InMemoryContainer([]),
+                $plugins,
                 true,
                 false,
             ),
+            $plugins,
         );
 
         $model = Model::new('content-template', ['title' => 'Hello World']);
@@ -151,13 +162,15 @@ final class ViewLayoutTest extends TestCase
 
     public function testThatAnExceptionWillBeThrownWhenRenderReceivesAnArrayWithoutATemplateName(): void
     {
+        $plugins = new PluginProxy(new InMemoryContainer([]));
         $view = new View(
             new PhpRenderer(
                 new MapResolver([]),
-                new InMemoryContainer([]),
+                $plugins,
                 true,
                 false,
             ),
+            $plugins,
         );
 
         $this->expectException(RenderingFailed::class);

--- a/test/Plugin/Partial/templates/layout.phtml
+++ b/test/Plugin/Partial/templates/layout.phtml
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+$content = $this->partial('page-title');
+
+echo $this->headTitle()->append('Layout')
+    ->setSeparator(' - ');
+
+echo $content;

--- a/test/Plugin/Partial/templates/page-title.phtml
+++ b/test/Plugin/Partial/templates/page-title.phtml
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+$this->headTitle()->prepend('Partial');
+
+?>
+
+<p>Partial Content</p>

--- a/test/Plugin/PartialLoopTest.php
+++ b/test/Plugin/PartialLoopTest.php
@@ -7,6 +7,7 @@ namespace Looker\Test\Plugin;
 use Looker\Plugin\Partial;
 use Looker\Plugin\PartialLoop;
 use Looker\Renderer\PhpRenderer;
+use Looker\Renderer\PluginProxy;
 use Looker\Template\MapResolver;
 use Looker\Test\InMemoryContainer;
 use PHPUnit\Framework\TestCase;
@@ -19,7 +20,8 @@ class PartialLoopTest extends TestCase
     {
         parent::setUp();
 
-        $plugins = new InMemoryContainer([]);
+        $container = new InMemoryContainer([]);
+        $plugins = new PluginProxy($container);
         $renderer = new PhpRenderer(
             new MapResolver([
                 'li' => __DIR__ . '/Partial/templates/list-item.phtml',
@@ -32,8 +34,8 @@ class PartialLoopTest extends TestCase
 
         $this->plugin = new PartialLoop($renderer);
         $partial = new Partial($renderer);
-        $plugins->setService('partialLoop', $this->plugin);
-        $plugins->setService('partial', $partial);
+        $container->setService('partialLoop', $this->plugin);
+        $container->setService('partial', $partial);
     }
 
     public function testThatAPartialWillBeRenderedAsExpected(): void

--- a/test/Plugin/PartialTest.php
+++ b/test/Plugin/PartialTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Looker\Test\Plugin;
 
+use Laminas\Escaper\Escaper;
+use Looker\Plugin\HeadTitle;
 use Looker\Plugin\Partial;
 use Looker\Renderer\PhpRenderer;
 use Looker\Template\MapResolver;
@@ -24,6 +26,8 @@ class PartialTest extends TestCase
                 new MapResolver([
                     'simple' => __DIR__ . '/Partial/templates/simple-partial.phtml',
                     'nested' => __DIR__ . '/Partial/templates/parent.phtml',
+                    'layout' => __DIR__ . '/Partial/templates/layout.phtml',
+                    'page-title' => __DIR__ . '/Partial/templates/page-title.phtml',
                 ]),
                 $plugins,
                 true,
@@ -31,6 +35,7 @@ class PartialTest extends TestCase
             ),
         );
         $plugins->setService('partial', $this->plugin);
+        $plugins->setService('headTitle', new HeadTitle(new Escaper()));
     }
 
     public function testThatAPartialWillBeRenderedAsExpected(): void
@@ -43,14 +48,14 @@ class PartialTest extends TestCase
         self::assertSame('bar.foo', $this->plugin->__invoke('nested', ['value' => 'bar', 'child' => 'foo']));
     }
 
-    /**
-     * @TODO Solve partials calling stateful plugins without those plugins being
-     *       cleared at the end of each render step
-     */
     public function testPartialsWithStatefulPluginCallsDoNotResetPluginState(): void
     {
-        self::markTestIncomplete(
-            'Currently, calls to stateful plugins will cause a state reset after the partial render.',
-        );
+        $expect = <<<'HTML'
+            <title>Partial - Layout</title>
+            <p>Partial Content</p>
+            
+            HTML;
+
+        self::assertSame($expect, $this->plugin->__invoke('layout'));
     }
 }

--- a/test/Plugin/PartialTest.php
+++ b/test/Plugin/PartialTest.php
@@ -8,6 +8,7 @@ use Laminas\Escaper\Escaper;
 use Looker\Plugin\HeadTitle;
 use Looker\Plugin\Partial;
 use Looker\Renderer\PhpRenderer;
+use Looker\Renderer\PluginProxy;
 use Looker\Template\MapResolver;
 use Looker\Test\InMemoryContainer;
 use PHPUnit\Framework\TestCase;
@@ -20,7 +21,8 @@ class PartialTest extends TestCase
     {
         parent::setUp();
 
-        $plugins = new InMemoryContainer([]);
+        $container = new InMemoryContainer([]);
+        $plugins = new PluginProxy($container);
         $this->plugin = new Partial(
             new PhpRenderer(
                 new MapResolver([
@@ -34,8 +36,8 @@ class PartialTest extends TestCase
                 false,
             ),
         );
-        $plugins->setService('partial', $this->plugin);
-        $plugins->setService('headTitle', new HeadTitle(new Escaper()));
+        $container->setService('partial', $this->plugin);
+        $container->setService('headTitle', new HeadTitle(new Escaper()));
     }
 
     public function testThatAPartialWillBeRenderedAsExpected(): void

--- a/test/Renderer/Factory/PhpRendererFactoryTest.php
+++ b/test/Renderer/Factory/PhpRendererFactoryTest.php
@@ -8,6 +8,7 @@ use Looker\ConfigurationError;
 use Looker\PluginManager;
 use Looker\Renderer\Factory\PhpRendererFactory;
 use Looker\Renderer\PhpRenderer;
+use Looker\Renderer\PluginProxy;
 use Looker\Template\MapResolver;
 use Looker\Template\Resolver;
 use Looker\Test\InMemoryContainer;
@@ -72,7 +73,7 @@ class PhpRendererFactoryTest extends TestCase
                 ],
             ],
             Resolver::class => new MapResolver([]),
-            PluginManager::class => new InMemoryContainer(),
+            PluginManager::class => new PluginProxy(new InMemoryContainer()),
         ]));
 
         self::assertInstanceOf(PhpRenderer::class, $renderer);

--- a/test/Renderer/PluginProxyTest.php
+++ b/test/Renderer/PluginProxyTest.php
@@ -83,6 +83,7 @@ class PluginProxyTest extends TestCase
         self::assertSame('mary had a little lamb', $value);
     }
 
+    /** @psalm-suppress MixedMethodCall */
     public function testThatUsedStatefulPluginsCanBeReset(): void
     {
         $a = new Stateful();
@@ -125,5 +126,15 @@ class PluginProxyTest extends TestCase
 
         $value = $proxy->somePlugin();
         self::assertSame('foo', $value);
+    }
+
+    public function testHas(): void
+    {
+        $proxy = new PluginProxy(new InMemoryContainer([
+            'somePlugin' => new NotInvokable(),
+        ]));
+
+        self::assertTrue($proxy->has('somePlugin'));
+        self::assertFalse($proxy->has('foo'));
     }
 }

--- a/test/Renderer/Plugins/Stateful.php
+++ b/test/Renderer/Plugins/Stateful.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Looker\Test\Integration\ResetPluginState\Plugins;
+namespace Looker\Test\Renderer\Plugins;
 
 use Looker\Plugin\StatefulPlugin;
 


### PR DESCRIPTION
The renderer cannot clear the state of stateful plugins for _every render_ because it defeats the point of maintaining any state.

This is particularly obvious when using the partial plugin, which may very well mutate state in stateful plugins, but because this plugin simply defers to the template renderer, it was clearing the state of all plugins, just by rendering a partial.

The template renderer, now composes a persistent plugin proxy for tracking plugin execution and exposes a method to clear state from the proxy context - which is a better place for this behaviour anyway.

Because the template renderer cannot possibly know _when_ it should clear plugin state, a method is added to the interface to proxy to the, er, proxy.

Actually clearing the state occurs in `View` now, after we have performed a "full" render.

The next logical step is to create an interface for a "Plugin Manager" that replaces the proxy, and use dependency injection to make the plugin manager available to everything else that might need to either use it, or manage plugin state.