### PR TITLE
Boolean Attribute Improvements

### DIFF
--- a/src/Plugin/HtmlAttributes.php
+++ b/src/Plugin/HtmlAttributes.php
@@ -54,6 +54,15 @@ final readonly class HtmlAttributes
                 );
             }
 
+            if ($value === false) {
+                continue;
+            }
+
+            if ($value === true) {
+                $attributeString[] = $key;
+                continue;
+            }
+
             $value = $this->escaper->escapeHtmlAttr((string) $value);
             $quote = str_contains($value, '"') ? "'" : '"';
             $attributeString[] = sprintf('%2$s=%1$s%3$s%1$s', $quote, $key, $value);

--- a/test/Plugin/HtmlAttributesTest.php
+++ b/test/Plugin/HtmlAttributesTest.php
@@ -54,4 +54,16 @@ class HtmlAttributesTest extends TestCase
             'something' => ['not-scalar' => ['Oh noes']],
         ]);
     }
+
+    public function testThatBooleanTrueAttributeValuesWillOnlyContainTheKey(): void
+    {
+        $plugin = new HtmlAttributes(new Escaper());
+        self::assertSame('disabled monkeys="1"', $plugin->__invoke(['disabled' => true, 'monkeys' => 1]));
+    }
+
+    public function testThatBooleanFalseAttributesWillBeOmitted(): void
+    {
+        $plugin = new HtmlAttributes(new Escaper());
+        self::assertSame('monkeys="1"', $plugin->__invoke(['disabled' => false, 'monkeys' => 1]));
+    }
 }


### PR DESCRIPTION
- Boolean `false` attributes should be omitted
- Boolean `true` attributes should only contain the key