### PR TITLE
Null should be an acceptable value for an attribute.

### DIFF
--- a/src/Plugin/HtmlAttributes.php
+++ b/src/Plugin/HtmlAttributes.php
@@ -48,10 +48,15 @@ final readonly class HtmlAttributes
                 $value = implode(' ', array_map(static fn (string|int $value): string => (string) $value, $value));
             }
 
+            if ($value === null) {
+                $value = '';
+            }
+
             if (! is_scalar($value)) {
-                throw new InvalidArgumentException(
-                    'HTML attribute arrays can only contain arrays with scalar values',
-                );
+                throw new InvalidArgumentException(sprintf(
+                    'HTML attribute arrays can only contain arrays with scalar values. The attribute "%s" is invalid',
+                    $key,
+                ));
             }
 
             if ($value === false) {

--- a/test/Plugin/HtmlAttributesTest.php
+++ b/test/Plugin/HtmlAttributesTest.php
@@ -49,7 +49,9 @@ class HtmlAttributesTest extends TestCase
     public function testThatNestedArraysWillCauseAnException(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('HTML attribute arrays can only contain arrays with scalar values');
+        $this->expectExceptionMessage(
+            'HTML attribute arrays can only contain arrays with scalar values. The attribute "something" is invalid',
+        );
         (new HtmlAttributes(new Escaper()))->__invoke([
             'something' => ['not-scalar' => ['Oh noes']],
         ]);
@@ -65,5 +67,11 @@ class HtmlAttributesTest extends TestCase
     {
         $plugin = new HtmlAttributes(new Escaper());
         self::assertSame('monkeys="1"', $plugin->__invoke(['disabled' => false, 'monkeys' => 1]));
+    }
+
+    public function testThatAttributeValuesCanBeNull(): void
+    {
+        $plugin = new HtmlAttributes(new Escaper());
+        self::assertSame('foo="bar" baz=""', $plugin->__invoke(['foo' => 'bar', 'baz' => null]));
     }
 }


### PR DESCRIPTION
Also improves the error message when a non-scalar attribute cannot be serialised.