### PR TITLE
Relax acceptable types for model variables

### DIFF
--- a/src/Model/Model.php
+++ b/src/Model/Model.php
@@ -7,13 +7,16 @@ namespace Looker\Model;
 use Override;
 
 use function array_merge;
+use function get_object_vars;
+use function is_iterable;
+use function iterator_to_array;
 
 /** @psalm-immutable */
 final readonly class Model implements ViewModel
 {
     /**
      * @param non-empty-string $template
-     * @param array<non-empty-string, mixed> $variables
+     * @param array<string, mixed> $variables
      * @param list<ChildModel> $childModels
      */
     private function __construct(
@@ -26,20 +29,36 @@ final readonly class Model implements ViewModel
 
     /**
      * @param non-empty-string $template
-     * @param array<non-empty-string, mixed> $variables
+     * @param array<string, mixed>|object $variables
      */
-    public static function new(string $template, array $variables = []): self
+    public static function new(string $template, array|object $variables = []): self
     {
-        return new self($template, $variables, [], false);
+        return new self($template, self::castVariables($variables), [], false);
     }
 
     /**
      * @param non-empty-string $template
-     * @param array<non-empty-string, mixed> $variables
+     * @param array<string, mixed> $variables
      */
     public static function terminal(string $template, array $variables = []): self
     {
-        return new self($template, $variables, [], true);
+        return new self($template, self::castVariables($variables), [], true);
+    }
+
+    /**
+     * @param array<string, mixed>|object $variables
+     *
+     * @return array<string, mixed>
+     */
+    private static function castVariables(array|object $variables): array
+    {
+        if (is_iterable($variables)) {
+            /** @psalm-var array<string, mixed> */
+            return iterator_to_array($variables);
+        }
+
+        /** @psalm-var array<string, mixed> */
+        return get_object_vars($variables);
     }
 
     #[Override]

--- a/src/Model/ViewModel.php
+++ b/src/Model/ViewModel.php
@@ -13,7 +13,7 @@ interface ViewModel
     /** @param non-empty-string $name */
     public function withTemplate(string $name): static;
 
-    /** @return array<non-empty-string, mixed> */
+    /** @return array<string, mixed> */
     public function variables(): array;
 
     /** @return list<ChildModel> */
@@ -27,7 +27,7 @@ interface ViewModel
      *
      * All existing variables are removed and replaced with the argument
      *
-     * @param array<non-empty-string, mixed> $variables
+     * @param array<string, mixed> $variables
      */
     public function replaceVariables(array $variables): static;
 
@@ -37,7 +37,7 @@ interface ViewModel
      * This operation performs a merge between the current variables and the given argument where variables in the
      * argument take precedence.
      *
-     * @param array<non-empty-string, mixed> $variables
+     * @param array<string, mixed> $variables
      */
     public function mergeReplace(array $variables): static;
 
@@ -47,7 +47,7 @@ interface ViewModel
      * This operation performs a merge between the current variables and the given argument where existing variables
      * take precedence.
      *
-     * @param array<non-empty-string, mixed> $variables
+     * @param array<string, mixed> $variables
      */
     public function mergeRetain(array $variables): static;
 

--- a/src/Renderer/Target.php
+++ b/src/Renderer/Target.php
@@ -26,7 +26,7 @@ final class Target
 
     /**
      * @param non-empty-string $__template
-     * @param array<non-empty-string, mixed> $__variables
+     * @param array<string, mixed> $__variables
      */
     public function __construct(
         private readonly string $__template,

--- a/test/Model/ModelTest.php
+++ b/test/Model/ModelTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Looker\Test\Model;
 
+use ArrayObject;
 use Looker\Model\ChildModel;
 use Looker\Model\Model;
 use Looker\Model\TerminalModelCannotBeChild;
@@ -141,5 +142,32 @@ final class ModelTest extends TestCase
         self::assertSame('bar', $clone->template());
 
         self::assertSame($model->variables(), $clone->variables());
+    }
+
+    public function testModelWithPoPo(): void
+    {
+        $vars = new readonly class () {
+            public string $a;
+            public int $b;
+
+            public function __construct()
+            {
+                $this->a = 'a';
+                $this->b = 1;
+            }
+        };
+
+        $model = Model::new('foo', $vars);
+
+        self::assertSame(['a' => 'a', 'b' => 1], $model->variables());
+    }
+
+    public function testModelWithIterableObject(): void
+    {
+        $vars = new ArrayObject(['a' => 'a', 'b' => 1]);
+
+        $model = Model::new('foo', $vars);
+
+        self::assertSame(['a' => 'a', 'b' => 1], $model->variables());
     }
 }


### PR DESCRIPTION
Changes variable storage from `array<non-empty-string, mixed>` to `array<string, mixed>` because life is too short.

Allow objects as variables in Model named constructors and call either `iterator_to_array`, or `get_object_vars` on them.