### PR TITLE
Drop `webmozart/assert` in favour of `azjezz/psl`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,13 +21,13 @@
     },
     "require": {
         "php": "~8.3 || ~8.4 || ~8.5",
-        "gsteel/dot": "^1.8",
+        "azjezz/psl": "^4.2",
         "laminas/laminas-escaper": "^2.15",
-        "psr/container": "^1.1.2 || ^2.0",
-        "webmozart/assert": "^1.11"
+        "psr/container": "^1.1.2 || ^2.0"
     },
     "require-dev": {
         "doctrine/coding-standard": "^14.0.0",
+        "php-standard-library/psalm-plugin": "^2.3",
         "phpunit/phpunit": "^12.5.4",
         "psalm/plugin-phpunit": "^0.19.5",
         "squizlabs/php_codesniffer": "^4.0.1",

--- a/composer.json
+++ b/composer.json
@@ -46,19 +46,5 @@
         "psr-4": {
             "Looker\\Test\\": "test"
         }
-    },
-    "scripts": {
-        "check": [
-            "@cs-check",
-            "@static-analysis",
-            "@test",
-            "@check-deps"
-        ],
-        "cs-check": "phpcs",
-        "cs-fix": "phpcbf",
-        "static-analysis": "psalm --shepherd --stats",
-        "check-deps": "composer-require-checker check",
-        "infection": "infection --configuration=mutants.json",
-        "test": "phpunit --colors=always"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,36 +4,55 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d0acdac3469e736fc62793538a389824",
+    "content-hash": "64c64f41ca714ea9d49b0fbfb8cd604b",
     "packages": [
         {
-            "name": "gsteel/dot",
-            "version": "1.9.0",
+            "name": "azjezz/psl",
+            "version": "4.2.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/gsteel/dot.git",
-                "reference": "3b583bfe370e477826b4d20ab17a5abc6a9aabc6"
+                "url": "https://github.com/azjezz/psl.git",
+                "reference": "15153a64c9824335ce11654522e7d88de762d39e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/gsteel/dot/zipball/3b583bfe370e477826b4d20ab17a5abc6a9aabc6",
-                "reference": "3b583bfe370e477826b4d20ab17a5abc6a9aabc6",
+                "url": "https://api.github.com/repos/azjezz/psl/zipball/15153a64c9824335ce11654522e7d88de762d39e",
+                "reference": "15153a64c9824335ce11654522e7d88de762d39e",
                 "shasum": ""
             },
             "require": {
-                "php": "~8.2.0 || ~8.3 || ~8.4 || ~8.5"
+                "ext-bcmath": "*",
+                "ext-intl": "*",
+                "ext-json": "*",
+                "ext-mbstring": "*",
+                "ext-sodium": "*",
+                "php": "~8.3.0 || ~8.4.0 || ~8.5.0",
+                "revolt/event-loop": "^1.0.7"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^14.0.0",
-                "phpunit/phpunit": "^11.5.42",
-                "psalm/plugin-phpunit": "^0.19.5",
-                "squizlabs/php_codesniffer": "^4.0.0",
-                "vimeo/psalm": "^6.13.1"
+                "carthage-software/mago": "^1.0.0-beta.32",
+                "infection/infection": "^0.31.2",
+                "php-coveralls/php-coveralls": "^2.7.0",
+                "phpbench/phpbench": "^1.4.0",
+                "phpunit/phpunit": "^9.6.22"
+            },
+            "suggest": {
+                "php-standard-library/phpstan-extension": "PHPStan integration",
+                "php-standard-library/psalm-plugin": "Psalm integration"
             },
             "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/hhvm/hsl",
+                    "name": "hhvm/hsl"
+                }
+            },
             "autoload": {
+                "files": [
+                    "src/bootstrap.php"
+                ],
                 "psr-4": {
-                    "GSteel\\": "src/"
+                    "Psl\\": "src/Psl"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -42,25 +61,26 @@
             ],
             "authors": [
                 {
-                    "name": "George Steel",
-                    "email": "george@net-glue.co.uk"
+                    "name": "azjezz",
+                    "email": "azjezz@protonmail.com"
                 }
             ],
-            "description": "A Utility for retrieving typed values from nested arrays",
-            "homepage": "https://github.com/gsteel/dot",
-            "keywords": [
-                "array",
-                "config",
-                "configuration",
-                "dot",
-                "utility"
-            ],
+            "description": "PHP Standard Library",
             "support": {
-                "issues": "https://github.com/gsteel/dot/issues",
-                "rss": "https://github.com/gsteel/dot/releases.atom",
-                "source": "https://github.com/gsteel/dot"
+                "issues": "https://github.com/azjezz/psl/issues",
+                "source": "https://github.com/azjezz/psl/tree/4.2.0"
             },
-            "time": "2025-10-05T20:50:53+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/azjezz",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/veewee",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-10-25T08:31:40+00:00"
         },
         {
             "name": "laminas/laminas-escaper",
@@ -177,39 +197,37 @@
             "time": "2021-11-05T16:47:00+00:00"
         },
         {
-            "name": "webmozart/assert",
-            "version": "1.12.1",
+            "name": "revolt/event-loop",
+            "version": "v1.0.8",
             "source": {
                 "type": "git",
-                "url": "https://github.com/webmozarts/assert.git",
-                "reference": "9be6926d8b485f55b9229203f962b51ed377ba68"
+                "url": "https://github.com/revoltphp/event-loop.git",
+                "reference": "b6fc06dce8e9b523c9946138fa5e62181934f91c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozarts/assert/zipball/9be6926d8b485f55b9229203f962b51ed377ba68",
-                "reference": "9be6926d8b485f55b9229203f962b51ed377ba68",
+                "url": "https://api.github.com/repos/revoltphp/event-loop/zipball/b6fc06dce8e9b523c9946138fa5e62181934f91c",
+                "reference": "b6fc06dce8e9b523c9946138fa5e62181934f91c",
                 "shasum": ""
             },
             "require": {
-                "ext-ctype": "*",
-                "ext-date": "*",
-                "ext-filter": "*",
-                "php": "^7.2 || ^8.0"
+                "php": ">=8.1"
             },
-            "suggest": {
-                "ext-intl": "",
-                "ext-simplexml": "",
-                "ext-spl": ""
+            "require-dev": {
+                "ext-json": "*",
+                "jetbrains/phpstorm-stubs": "^2019.3",
+                "phpunit/phpunit": "^9",
+                "psalm/phar": "^5.15"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.10-dev"
+                    "dev-main": "1.x-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
-                    "Webmozart\\Assert\\": "src/"
+                    "Revolt\\": "src"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -218,21 +236,37 @@
             ],
             "authors": [
                 {
-                    "name": "Bernhard Schussek",
-                    "email": "bschussek@gmail.com"
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                },
+                {
+                    "name": "Cees-Jan Kiewiet",
+                    "email": "ceesjank@gmail.com"
+                },
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
                 }
             ],
-            "description": "Assertions to validate method input/output with nice error messages.",
+            "description": "Rock-solid event loop for concurrent PHP applications.",
             "keywords": [
-                "assert",
-                "check",
-                "validate"
+                "async",
+                "asynchronous",
+                "concurrency",
+                "event",
+                "event-loop",
+                "non-blocking",
+                "scheduler"
             ],
             "support": {
-                "issues": "https://github.com/webmozarts/assert/issues",
-                "source": "https://github.com/webmozarts/assert/tree/1.12.1"
+                "issues": "https://github.com/revoltphp/event-loop/issues",
+                "source": "https://github.com/revoltphp/event-loop/tree/v1.0.8"
             },
-            "time": "2025-10-29T15:56:20+00:00"
+            "time": "2025-08-27T21:33:23+00:00"
         }
     ],
     "packages-dev": [
@@ -2244,6 +2278,60 @@
             "time": "2022-02-21T01:04:05+00:00"
         },
         {
+            "name": "php-standard-library/psalm-plugin",
+            "version": "2.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-standard-library/psalm-plugin.git",
+                "reference": "bf6d560ae498966150bc66a42e02744b0ee242c5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-standard-library/psalm-plugin/zipball/bf6d560ae498966150bc66a42e02744b0ee242c5",
+                "reference": "bf6d560ae498966150bc66a42e02744b0ee242c5",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.1",
+                "vimeo/psalm": ">=5.16"
+            },
+            "conflict": {
+                "azjezz/psl": "<2.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^2.18",
+                "roave/security-advisories": "dev-master",
+                "squizlabs/php_codesniffer": "^3.5"
+            },
+            "type": "psalm-plugin",
+            "extra": {
+                "psalm": {
+                    "pluginClass": "Psl\\Psalm\\Plugin"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psl\\Psalm\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "azjezz",
+                    "email": "azjezz@protonmail.com"
+                }
+            ],
+            "description": "Psalm plugin for the PHP Standard Library",
+            "support": {
+                "issues": "https://github.com/php-standard-library/psalm-plugin/issues",
+                "source": "https://github.com/php-standard-library/psalm-plugin/tree/2.3.0"
+            },
+            "time": "2023-11-28T12:22:48+00:00"
+        },
+        {
             "name": "phpdocumentor/reflection-common",
             "version": "2.2.0",
             "source": {
@@ -3120,78 +3208,6 @@
                 "source": "https://github.com/php-fig/log/tree/3.0.2"
             },
             "time": "2024-09-11T13:17:53+00:00"
-        },
-        {
-            "name": "revolt/event-loop",
-            "version": "v1.0.8",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/revoltphp/event-loop.git",
-                "reference": "b6fc06dce8e9b523c9946138fa5e62181934f91c"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/revoltphp/event-loop/zipball/b6fc06dce8e9b523c9946138fa5e62181934f91c",
-                "reference": "b6fc06dce8e9b523c9946138fa5e62181934f91c",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.1"
-            },
-            "require-dev": {
-                "ext-json": "*",
-                "jetbrains/phpstorm-stubs": "^2019.3",
-                "phpunit/phpunit": "^9",
-                "psalm/phar": "^5.15"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "1.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Revolt\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Aaron Piotrowski",
-                    "email": "aaron@trowski.com"
-                },
-                {
-                    "name": "Cees-Jan Kiewiet",
-                    "email": "ceesjank@gmail.com"
-                },
-                {
-                    "name": "Christian Lück",
-                    "email": "christian@clue.engineering"
-                },
-                {
-                    "name": "Niklas Keller",
-                    "email": "me@kelunik.com"
-                }
-            ],
-            "description": "Rock-solid event loop for concurrent PHP applications.",
-            "keywords": [
-                "async",
-                "asynchronous",
-                "concurrency",
-                "event",
-                "event-loop",
-                "non-blocking",
-                "scheduler"
-            ],
-            "support": {
-                "issues": "https://github.com/revoltphp/event-loop/issues",
-                "source": "https://github.com/revoltphp/event-loop/tree/v1.0.8"
-            },
-            "time": "2025-08-27T21:33:23+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -5349,6 +5365,68 @@
                 "source": "https://github.com/vimeo/psalm"
             },
             "time": "2025-12-23T15:36:48+00:00"
+        },
+        {
+            "name": "webmozart/assert",
+            "version": "2.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webmozarts/assert.git",
+                "reference": "ce6a2f100c404b2d32a1dd1270f9b59ad4f57649"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webmozarts/assert/zipball/ce6a2f100c404b2d32a1dd1270f9b59ad4f57649",
+                "reference": "ce6a2f100c404b2d32a1dd1270f9b59ad4f57649",
+                "shasum": ""
+            },
+            "require": {
+                "ext-ctype": "*",
+                "ext-date": "*",
+                "ext-filter": "*",
+                "php": "^8.2"
+            },
+            "suggest": {
+                "ext-intl": "",
+                "ext-simplexml": "",
+                "ext-spl": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-feature/2-0": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Webmozart\\Assert\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                },
+                {
+                    "name": "Woody Gilk",
+                    "email": "woody.gilk@gmail.com"
+                }
+            ],
+            "description": "Assertions to validate method input/output with nice error messages.",
+            "keywords": [
+                "assert",
+                "check",
+                "validate"
+            ],
+            "support": {
+                "issues": "https://github.com/webmozarts/assert/issues",
+                "source": "https://github.com/webmozarts/assert/tree/2.1.2"
+            },
+            "time": "2026-01-13T14:02:24+00:00"
         }
     ],
     "aliases": [],

--- a/mutants.json
+++ b/mutants.json
@@ -14,6 +14,5 @@
     "mutators": {
         "@default": true
     },
-    "minCoveredMsi": 85,
-    "minMsi": 85
+    "minMsi": 90
 }

--- a/psalm.xml
+++ b/psalm.xml
@@ -27,6 +27,7 @@
     </issueHandlers>
     <plugins>
         <pluginClass class="Psalm\PhpUnitPlugin\Plugin"/>
+        <pluginClass class="Psl\Psalm\Plugin"/>
     </plugins>
     <stubs>
         <file name=".psr-container.php.stub" preloadClasses="true" />

--- a/src/Plugin/Factory/BasePathFactory.php
+++ b/src/Plugin/Factory/BasePathFactory.php
@@ -4,25 +4,33 @@ declare(strict_types=1);
 
 namespace Looker\Plugin\Factory;
 
-use GSteel\Dot;
 use Looker\Plugin\BasePath;
 use Psr\Container\ContainerInterface;
-use Webmozart\Assert\Assert;
 
-use function assert;
+use function Psl\Type\non_empty_string;
+use function Psl\Type\null;
+use function Psl\Type\optional;
+use function Psl\Type\shape;
+use function Psl\Type\union;
 
 final class BasePathFactory
 {
     public function __invoke(ContainerInterface $container): BasePath
     {
-        $config = $container->has('config')
-            ? $container->get('config')
-            : [];
-        Assert::isArray($config);
+        $config = optional(shape([
+            'looker' => optional(shape([
+                'pluginConfig' => optional(shape([
+                    'basePath' => optional(union(non_empty_string(), null())),
+                ], true)),
+            ], true)),
+        ], true))->assert(
+            $container->has('config')
+                ? $container->get('config')
+                : [],
+        );
 
-        $path = Dot::stringOrNull('looker.pluginConfig.basePath', $config) ?? '/';
-        assert($path !== '');
-
-        return new BasePath($path);
+        return new BasePath(
+            $config['looker']['pluginConfig']['basePath'] ?? '/',
+        );
     }
 }

--- a/src/Plugin/Factory/DefaultDoctype.php
+++ b/src/Plugin/Factory/DefaultDoctype.php
@@ -4,25 +4,31 @@ declare(strict_types=1);
 
 namespace Looker\Plugin\Factory;
 
-use GSteel\Dot;
 use Looker\Value\Doctype;
-use Looker\Value\Doctype as DoctypeEnum;
 use Psr\Container\ContainerInterface;
-use Webmozart\Assert\Assert;
+
+use function Psl\Type\instance_of;
+use function Psl\Type\null;
+use function Psl\Type\optional;
+use function Psl\Type\shape;
+use function Psl\Type\union;
 
 final class DefaultDoctype
 {
     public static function retrieve(ContainerInterface $container): Doctype
     {
-        $config = $container->has('config')
-            ? $container->get('config')
-            : [];
-        Assert::isArray($config);
+        $config = optional(shape([
+            'looker' => optional(shape([
+                'pluginConfig' => optional(shape([
+                    'doctype' => optional(union(instance_of(Doctype::class), null())),
+                ], true)),
+            ], true)),
+        ], true))->assert(
+            $container->has('config')
+                ? $container->get('config')
+                : [],
+        );
 
-        /** @psalm-var mixed $default */
-        $default = Dot::valueOrNull('looker.pluginConfig.doctype', $config);
-        $default = $default instanceof DoctypeEnum ? $default : DoctypeEnum::HTML5;
-
-        return $default;
+        return $config['looker']['pluginConfig']['doctype'] ?? Doctype::HTML5;
     }
 }

--- a/src/Plugin/Factory/EscaperFactory.php
+++ b/src/Plugin/Factory/EscaperFactory.php
@@ -4,25 +4,29 @@ declare(strict_types=1);
 
 namespace Looker\Plugin\Factory;
 
-use GSteel\Dot;
 use Laminas\Escaper\Escaper;
 use Psr\Container\ContainerInterface;
-use Webmozart\Assert\Assert;
 
-use function assert;
+use function Psl\Type\non_empty_string;
+use function Psl\Type\null;
+use function Psl\Type\optional;
+use function Psl\Type\shape;
+use function Psl\Type\union;
 
 final class EscaperFactory
 {
     public function __invoke(ContainerInterface $container): Escaper
     {
-        $config = $container->has('config')
-            ? $container->get('config')
-            : [];
-        Assert::isArray($config);
+        $config = optional(shape([
+            'looker' => optional(shape([
+                'encoding' => optional(union(non_empty_string(), null())),
+            ], true)),
+        ], true))->assert(
+            $container->has('config')
+                ? $container->get('config')
+                : [],
+        );
 
-        $encoding = Dot::stringDefault('looker.encoding', $config, 'utf-8');
-        assert($encoding !== '');
-
-        return new Escaper($encoding);
+        return new Escaper($config['looker']['encoding'] ?? 'utf-8');
     }
 }

--- a/src/Plugin/Factory/HeadTitleFactory.php
+++ b/src/Plugin/Factory/HeadTitleFactory.php
@@ -4,30 +4,41 @@ declare(strict_types=1);
 
 namespace Looker\Plugin\Factory;
 
-use GSteel\Dot;
 use Laminas\Escaper\Escaper;
 use Looker\Plugin\HeadTitle;
 use Psr\Container\ContainerInterface;
-use Webmozart\Assert\Assert;
+
+use function Psl\Type\non_empty_string;
+use function Psl\Type\null;
+use function Psl\Type\optional;
+use function Psl\Type\shape;
+use function Psl\Type\union;
 
 final class HeadTitleFactory
 {
     public function __invoke(ContainerInterface $container): HeadTitle
     {
-        $config = $container->has('config')
-            ? $container->get('config')
-            : [];
-        Assert::isArray($config);
-
-        $separator = Dot::stringOrNull('looker.pluginConfig.headTitle.separator', $config);
-        $fallback = Dot::stringOrNull('looker.pluginConfig.headTitle.fallbackTitle', $config);
+        $config = optional(shape([
+            'looker' => optional(shape([
+                'pluginConfig' => optional(shape([
+                    'headTitle' => optional(shape([
+                        'separator' => union(non_empty_string(), null()),
+                        'fallbackTitle' => union(non_empty_string(), null()),
+                    ], true)),
+                ], true)),
+            ], true)),
+        ], true))->assert(
+            $container->has('config')
+                ? $container->get('config')
+                : [],
+        );
 
         return new HeadTitle(
             $container->has(Escaper::class)
                 ? $container->get(Escaper::class)
                 : new Escaper(),
-            $separator === '' ? null : $separator,
-            $fallback === '' ? null : $fallback,
+            $config['looker']['pluginConfig']['headTitle']['separator'] ?? null,
+            $config['looker']['pluginConfig']['headTitle']['fallbackTitle'] ?? null,
         );
     }
 }

--- a/src/Renderer/Factory/PhpRendererFactory.php
+++ b/src/Renderer/Factory/PhpRendererFactory.php
@@ -4,24 +4,31 @@ declare(strict_types=1);
 
 namespace Looker\Renderer\Factory;
 
-use GSteel\Dot;
 use Looker\ConfigurationError;
 use Looker\PluginManager;
 use Looker\Renderer\PhpRenderer;
 use Looker\Template\Resolver;
 use Psr\Container\ContainerInterface;
 use Throwable;
-use Webmozart\Assert\Assert;
+
+use function Psl\Type\bool;
+use function Psl\Type\shape;
 
 final class PhpRendererFactory
 {
     public function __invoke(ContainerInterface $container): PhpRenderer
     {
         try {
-            $config = $container->get('config');
-            Assert::isArray($config);
-            $strictVars = Dot::bool('looker.strictVariables', $config);
-            $passScope = Dot::bool('looker.passScopeToChildren', $config);
+            $config = shape([
+                'looker' => shape([
+                    'strictVariables' => bool(),
+                    'passScopeToChildren' => bool(),
+                ], true),
+            ], true)->assert(
+                $container->has('config')
+                    ? $container->get('config')
+                    : [],
+            );
         } catch (Throwable) {
             throw new ConfigurationError(
                 'The PhpRenderer requires that the `config` array can be retrieved from the container, and '
@@ -33,8 +40,8 @@ final class PhpRendererFactory
         return new PhpRenderer(
             $container->get(Resolver::class),
             $container->get(PluginManager::class),
-            $strictVars,
-            $passScope,
+            $config['looker']['strictVariables'],
+            $config['looker']['passScopeToChildren'],
         );
     }
 }

--- a/src/Template/Factory/AggregateResolverFactory.php
+++ b/src/Template/Factory/AggregateResolverFactory.php
@@ -4,15 +4,18 @@ declare(strict_types=1);
 
 namespace Looker\Template\Factory;
 
-use GSteel\Dot;
 use Looker\ConfigurationError;
 use Looker\Template\AggregateResolver;
 use Looker\Template\Resolver;
 use Psr\Container\ContainerInterface;
 use Throwable;
-use Webmozart\Assert\Assert;
 
 use function array_map;
+use function Psl\Type\array_key;
+use function Psl\Type\dict;
+use function Psl\Type\instance_of;
+use function Psl\Type\non_empty_string;
+use function Psl\Type\shape;
 
 final class AggregateResolverFactory
 {
@@ -20,14 +23,19 @@ final class AggregateResolverFactory
     {
         try {
             $config = $container->has('config') ? $container->get('config') : null;
-            Assert::isArray($config);
-            $serviceNames = Dot::array('looker.templates.aggregate', $config);
-            $services = array_map(static function (string $serviceName) use ($container): Resolver {
-                $service = $container->get($serviceName);
-                Assert::isInstanceOf($service, Resolver::class);
-
-                return $service;
-            }, $serviceNames);
+            $config = shape([
+                'looker' => shape([
+                    'templates' => shape([
+                        'aggregate' => dict(array_key(), non_empty_string()),
+                    ], true),
+                ], true),
+            ], true)->assert($config);
+            $services = array_map(
+                static fn (string $serviceName): Resolver => instance_of(Resolver::class)->assert(
+                    $container->get($serviceName),
+                ),
+                $config['looker']['templates']['aggregate'],
+            );
         } catch (Throwable) {
             throw new ConfigurationError(
                 'The aggregate template resolver requires that the `config` array is present in the '

--- a/src/Template/Factory/DirectoryResolverFactory.php
+++ b/src/Template/Factory/DirectoryResolverFactory.php
@@ -4,25 +4,28 @@ declare(strict_types=1);
 
 namespace Looker\Template\Factory;
 
-use GSteel\Dot;
 use Looker\ConfigurationError;
 use Looker\Template\DirectoryResolver;
 use Psr\Container\ContainerInterface;
 use Throwable;
-use Webmozart\Assert\Assert;
+
+use function Psl\Type\non_empty_string;
+use function Psl\Type\non_empty_vec;
+use function Psl\Type\shape;
 
 final class DirectoryResolverFactory
 {
     public function __invoke(ContainerInterface $container): DirectoryResolver
     {
         try {
-            $config = $container->has('config') ? $container->get('config') : null;
-            Assert::isArray($config);
-            $list = Dot::array('looker.templates.paths', $config);
-            Assert::isList($list);
-            Assert::notEmpty($list);
-            Assert::allStringNotEmpty($list);
-            $defaultSuffix = Dot::nonEmptyString('looker.templates.defaultSuffix', $config);
+            $config = shape([
+                'looker' => shape([
+                    'templates' => shape([
+                        'paths' => non_empty_vec(non_empty_string()),
+                        'defaultSuffix' => non_empty_string(),
+                    ], true),
+                ], true),
+            ], true)->assert($container->has('config') ? $container->get('config') : null);
         } catch (Throwable) {
             throw new ConfigurationError(
                 'The directory resolver requires that the `config` array is available in the container and '
@@ -32,6 +35,9 @@ final class DirectoryResolverFactory
             );
         }
 
-        return new DirectoryResolver($list, $defaultSuffix);
+        return new DirectoryResolver(
+            $config['looker']['templates']['paths'],
+            $config['looker']['templates']['defaultSuffix'],
+        );
     }
 }

--- a/src/Template/Factory/MapResolverFactory.php
+++ b/src/Template/Factory/MapResolverFactory.php
@@ -4,24 +4,27 @@ declare(strict_types=1);
 
 namespace Looker\Template\Factory;
 
-use GSteel\Dot;
 use Looker\ConfigurationError;
 use Looker\Template\MapResolver;
 use Psr\Container\ContainerInterface;
 use Throwable;
-use Webmozart\Assert\Assert;
+
+use function Psl\Type\dict;
+use function Psl\Type\non_empty_string;
+use function Psl\Type\shape;
 
 final class MapResolverFactory
 {
     public function __invoke(ContainerInterface $container): MapResolver
     {
         try {
-            $config = $container->has('config') ? $container->get('config') : null;
-            Assert::isArray($config);
-            $map = Dot::array('looker.templates.map', $config);
-            Assert::isMap($map);
-            Assert::allStringNotEmpty($map);
-            /** @psalm-var array<non-empty-string, non-empty-string> $map */
+            $config = shape([
+                'looker' => shape([
+                    'templates' => shape([
+                        'map' => dict(non_empty_string(), non_empty_string()),
+                    ], true),
+                ], true),
+            ], true)->assert($container->has('config') ? $container->get('config') : null);
         } catch (Throwable) {
             throw new ConfigurationError(
                 'The map resolver requires that `config` is an array available in the container and contains '
@@ -29,6 +32,6 @@ final class MapResolverFactory
             );
         }
 
-        return new MapResolver($map);
+        return new MapResolver($config['looker']['templates']['map']);
     }
 }

--- a/tools/infection/composer.json
+++ b/tools/infection/composer.json
@@ -11,6 +11,7 @@
         "php": "~8.3 || ~8.4 || ~8.5"
     },
     "require-dev": {
+        "php-standard-library/psalm-plugin": "^2.3",
         "psalm/plugin-phpunit": "^0.19.5",
         "roave/infection-static-analysis-plugin": "^1.43",
         "vimeo/psalm": "^6.14.3"

--- a/tools/infection/composer.lock
+++ b/tools/infection/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3c9d9b3da85d46a2d933320e3823c4a0",
+    "content-hash": "0af95ef1a505d08845e29005fc63e7cf",
     "packages": [],
     "packages-dev": [
         {
@@ -2352,6 +2352,60 @@
                 "source": "https://github.com/OndraM/ci-detector/tree/4.2.0"
             },
             "time": "2024-03-12T13:22:30+00:00"
+        },
+        {
+            "name": "php-standard-library/psalm-plugin",
+            "version": "2.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-standard-library/psalm-plugin.git",
+                "reference": "bf6d560ae498966150bc66a42e02744b0ee242c5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-standard-library/psalm-plugin/zipball/bf6d560ae498966150bc66a42e02744b0ee242c5",
+                "reference": "bf6d560ae498966150bc66a42e02744b0ee242c5",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.1",
+                "vimeo/psalm": ">=5.16"
+            },
+            "conflict": {
+                "azjezz/psl": "<2.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^2.18",
+                "roave/security-advisories": "dev-master",
+                "squizlabs/php_codesniffer": "^3.5"
+            },
+            "type": "psalm-plugin",
+            "extra": {
+                "psalm": {
+                    "pluginClass": "Psl\\Psalm\\Plugin"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psl\\Psalm\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "azjezz",
+                    "email": "azjezz@protonmail.com"
+                }
+            ],
+            "description": "Psalm plugin for the PHP Standard Library",
+            "support": {
+                "issues": "https://github.com/php-standard-library/psalm-plugin/issues",
+                "source": "https://github.com/php-standard-library/psalm-plugin/tree/2.3.0"
+            },
+            "time": "2023-11-28T12:22:48+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",


### PR DESCRIPTION
Whilst PSL does require extensions - this lib is unlikely to get wide use, and I use PSL all the time and therefore have `intl` and `bcmath` installed already.

This patch also allows the removal of `gsteel/dot` because `shape()` makes it redundant