### PR TITLE
BC Break: Template Resolvers no longer throw exceptions

### DIFF
--- a/src/Renderer/PhpRenderer.php
+++ b/src/Renderer/PhpRenderer.php
@@ -37,7 +37,15 @@ final readonly class PhpRenderer implements Renderer
         }
 
         $file = $this->resolver->resolve($model->template());
+        if ($file === false) {
+            throw TemplateCannotBeResolved::becauseAllResolversAreExhausted($model->template(), $this->resolver);
+        }
 
-        return (new Target($file, $model->variables(), $this->plugins, $this->strictVariables))();
+        return new Target(
+            $file,
+            $model->variables(),
+            $this->plugins,
+            $this->strictVariables,
+        )();
     }
 }

--- a/src/Template/AggregateResolver.php
+++ b/src/Template/AggregateResolver.php
@@ -19,15 +19,17 @@ final readonly class AggregateResolver implements Resolver
     }
 
     #[Override]
-    public function resolve(string $name): string
+    public function resolve(string $name): string|false
     {
         foreach ($this->resolvers as $resolver) {
-            try {
-                return $resolver->resolve($name);
-            } catch (TemplateCannotBeResolved) {
+            $template = $resolver->resolve($name);
+            if ($template === false) {
+                continue;
             }
+
+            return $template;
         }
 
-        throw TemplateCannotBeResolved::becauseAllResolversAreExhausted($name, $this);
+        return false;
     }
 }

--- a/src/Template/DirectoryResolver.php
+++ b/src/Template/DirectoryResolver.php
@@ -29,8 +29,13 @@ final readonly class DirectoryResolver implements Resolver
     ) {
     }
 
+    /**
+     * @throws TemplateCannotBeResolved When the configured directories are invalid in some way.
+     *
+     * @inheritDoc
+     */
     #[Override]
-    public function resolve(string $name): string
+    public function resolve(string $name): string|false
     {
         foreach ($this->directories as $directory) {
             $path = $this->resolveFromDirectory($directory, $name);
@@ -41,7 +46,7 @@ final readonly class DirectoryResolver implements Resolver
             return $path;
         }
 
-        throw TemplateCannotBeResolved::becauseItCannotBeFoundOnDisk($name, $this);
+        return false;
     }
 
     /**
@@ -49,6 +54,9 @@ final readonly class DirectoryResolver implements Resolver
      * @param non-empty-string $name
      *
      * @return non-empty-string|null
+     *
+     * @throws TemplateCannotBeResolved When the configured directories contain path traversals.
+     * @throws TemplateCannotBeResolved When a configured directory does not exist.
      */
     private function resolveFromDirectory(string $directory, string $name): string|null
     {

--- a/src/Template/MapResolver.php
+++ b/src/Template/MapResolver.php
@@ -16,10 +16,10 @@ final readonly class MapResolver implements Resolver
     }
 
     #[Override]
-    public function resolve(string $name): string
+    public function resolve(string $name): string|false
     {
         if (! array_key_exists($name, $this->map)) {
-            throw TemplateCannotBeResolved::becauseItWasNotConfigured($name, $this);
+            return false;
         }
 
         return $this->map[$name];

--- a/src/Template/Resolver.php
+++ b/src/Template/Resolver.php
@@ -11,9 +11,7 @@ interface Resolver
      *
      * @param non-empty-string $name
      *
-     * @return non-empty-string
-     *
-     * @throws TemplateCannotBeResolved
+     * @return non-empty-string|false
      */
-    public function resolve(string $name): string;
+    public function resolve(string $name): string|false;
 }

--- a/src/Template/TemplateCannotBeResolved.php
+++ b/src/Template/TemplateCannotBeResolved.php
@@ -20,31 +20,12 @@ final class TemplateCannotBeResolved extends RuntimeException
         parent::__construct($message);
     }
 
-    /** @param non-empty-string $name */
-    public static function becauseItWasNotConfigured(string $name, Resolver $resolver): self
-    {
-        return new self(sprintf(
-            'The template named "%s" could not be resolved because it has not been configured in the resolver "%s".',
-            $name,
-            $resolver::class,
-        ), $resolver);
-    }
-
     /** @param non-empty-string $path */
     public static function becausePathIsNotADirectory(string $path, Resolver $resolver): self
     {
         return new self(sprintf(
             'The path provided for template resolution is not a directory: "%s"',
             $path,
-        ), $resolver);
-    }
-
-    /** @param non-empty-string $name */
-    public static function becauseItCannotBeFoundOnDisk(string $name, Resolver $resolver): self
-    {
-        return new self(sprintf(
-            'The template "%s" cannot be resolved to a file on the local filesystem',
-            $name,
         ), $resolver);
     }
 

--- a/src/View.php
+++ b/src/View.php
@@ -31,6 +31,8 @@ final readonly class View
     /**
      * @param array<non-empty-string, mixed>|ViewModel $viewModel
      * @param non-empty-string|null $template
+     *
+     * @throws RenderingFailed
      */
     public function render(array|ViewModel $viewModel, string|null $template = null): string
     {

--- a/test/Renderer/PhpRendererTest.php
+++ b/test/Renderer/PhpRendererTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Looker\Test\Renderer;
+
+use Looker\Model\Model;
+use Looker\PluginManager;
+use Looker\Renderer\PhpRenderer;
+use Looker\Template\MapResolver;
+use Looker\Template\TemplateCannotBeResolved;
+use PHPUnit\Framework\TestCase;
+
+final class PhpRendererTest extends TestCase
+{
+    public function testExceptionThrownWhenTheTemplateCannotBeResolved(): void
+    {
+        $renderer = new PhpRenderer(
+            new MapResolver([]),
+            self::createStub(PluginManager::class),
+            true,
+            false,
+        );
+
+        $this->expectException(TemplateCannotBeResolved::class);
+        $this->expectExceptionMessage(
+            'The template "whatever" cannot be resolved because none of the configured resolvers could find it',
+        );
+
+        $renderer->render(Model::new('whatever'));
+    }
+}

--- a/test/Template/AggregateResolverTest.php
+++ b/test/Template/AggregateResolverTest.php
@@ -6,7 +6,6 @@ namespace Looker\Test\Template;
 
 use Looker\Template\AggregateResolver;
 use Looker\Template\MapResolver;
-use Looker\Template\TemplateCannotBeResolved;
 use PHPUnit\Framework\TestCase;
 
 final class AggregateResolverTest extends TestCase
@@ -47,7 +46,7 @@ final class AggregateResolverTest extends TestCase
         );
     }
 
-    public function testExceptionThrownWhenNoResolversCanResolve(): void
+    public function testFalseIsReturnedWhenNoResolversCanResolve(): void
     {
         $map1 = new MapResolver([
             'foo' => __DIR__ . '/templates/more/templates.phtml',
@@ -59,9 +58,6 @@ final class AggregateResolverTest extends TestCase
 
         $resolver = new AggregateResolver($map1, $map2);
 
-        $this->expectException(TemplateCannotBeResolved::class);
-        $this->expectExceptionMessage('because none of the configured resolvers could find it');
-
-        $resolver->resolve('baz');
+        self::assertFalse($resolver->resolve('baz'));
     }
 }

--- a/test/Template/DirectoryResolverTest.php
+++ b/test/Template/DirectoryResolverTest.php
@@ -19,19 +19,14 @@ final class DirectoryResolverTest extends TestCase
         chmod(__DIR__ . '/templates/unreadable.phtml', 0644);
     }
 
-    public function testExceptionThrownWhenNoTemplatesCanBeFoundInAnyConfiguredDirectories(): void
+    public function testFalseIsReturnedWhenNoTemplatesCanBeFoundInAnyConfiguredDirectories(): void
     {
         $resolver = new DirectoryResolver([
             __DIR__ . '/templates/more',
             __DIR__ . '/templates/and-more/',
         ], 'phtml');
 
-        $this->expectException(TemplateCannotBeResolved::class);
-        $this->expectExceptionMessage(
-            'The template "does-not-exist" cannot be resolved to a file on the local filesystem',
-        );
-
-        $resolver->resolve('does-not-exist');
+        self::assertFalse($resolver->resolve('does-not-exist'));
     }
 
     public function testThatUnreadableFilesWillNotBeResolved(): void
@@ -41,11 +36,7 @@ final class DirectoryResolverTest extends TestCase
             __DIR__ . '/templates',
         ], 'phtml');
 
-        $this->expectException(TemplateCannotBeResolved::class);
-        $this->expectExceptionMessage(
-            'The template "unreadable" cannot be resolved to a file on the local filesystem',
-        );
-        $resolver->resolve('unreadable');
+        self::assertFalse($resolver->resolve('unreadable'));
     }
 
     public function testExceptionThrownWhenAConfiguredDirectoryIsNotADirectory(): void
@@ -152,5 +143,19 @@ final class DirectoryResolverTest extends TestCase
         );
 
         $resolver->resolve('../top.phtml');
+    }
+
+    public function testThatResolverExceptionsKeepAReferenceToTheFailingResolver(): void
+    {
+        $resolver = new DirectoryResolver([
+            __DIR__ . '/templates/more',
+        ], 'phtml');
+
+        try {
+            $resolver->resolve('../top.phtml');
+            self::fail('Expected an exception');
+        } catch (TemplateCannotBeResolved $e) {
+            self::assertSame($resolver, $e->resolver);
+        }
     }
 }

--- a/test/Template/MapResolverTest.php
+++ b/test/Template/MapResolverTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Looker\Test\Template;
 
 use Looker\Template\MapResolver;
-use Looker\Template\TemplateCannotBeResolved;
 use PHPUnit\Framework\TestCase;
 
 final class MapResolverTest extends TestCase
@@ -16,25 +15,10 @@ final class MapResolverTest extends TestCase
         self::assertSame('bar', $resolver->resolve('foo'));
     }
 
-    public function testThatAnExceptionIsThrownWhenATemplateCannotBeResolved(): void
+    public function testFalseIsReturnedWhenATemplateCannotBeResolved(): void
     {
         $resolver = new MapResolver(['foo' => 'bar']);
 
-        $this->expectException(TemplateCannotBeResolved::class);
-        $this->expectExceptionMessage('"fred"');
-
-        $resolver->resolve('fred');
-    }
-
-    public function testThatExceptionsHaveAReferenceToTheFailingResolver(): void
-    {
-        $resolver = new MapResolver(['foo' => 'bar']);
-
-        try {
-            $resolver->resolve('fred');
-            self::fail('An exception was not thrown');
-        } catch (TemplateCannotBeResolved $e) {
-            self::assertSame($resolver, $e->resolver);
-        }
+        self::assertFalse($resolver->resolve('fred'));
     }
 }


### PR DESCRIPTION
Using try/catch in a loop, such as in the aggregate resolver carries significant performance penalties.

This patch changes the return type for `resolve()` to `string|false` instead of throwing exceptions.

Various static constructors for `TemplateCannotBeResolved` have been removed as they are no longer used.