### PR TITLE
BC Break: `AttributeNormaliser` is now a service

### DIFF
--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -14,6 +14,7 @@ final class ConfigProvider
         return [
             'looker' => [
                 'encoding' => 'utf-8',
+                'permitUnknownAttributes' => true,
                 'strictVariables' => true,
                 'passScopeToChildren' => false,
                 'plugins' => $this->pluginDependencies(),
@@ -34,6 +35,7 @@ final class ConfigProvider
             ],
             'dependencies' => [
                 'factories' => [
+                    HTML\AttributeNormaliser::class => HTML\AttributeNormaliserFactory::class,
                     Renderer\PhpRenderer::class => Renderer\Factory\PhpRendererFactory::class,
                     Template\AggregateResolver::class => Template\Factory\AggregateResolverFactory::class,
                     Template\DirectoryResolver::class => Template\Factory\DirectoryResolverFactory::class,

--- a/src/HTML/AttributeNormaliser.php
+++ b/src/HTML/AttributeNormaliser.php
@@ -5,13 +5,18 @@ declare(strict_types=1);
 namespace Looker\HTML;
 
 use function array_change_key_case;
+use function is_bool;
 use function ksort;
 
 use const CASE_LOWER;
 
-/** @psalm-internal Looker */
-final class AttributeNormaliser
+final readonly class AttributeNormaliser
 {
+    public function __construct(
+        public bool $permitUnknownAttributes = true,
+    ) {
+    }
+
     /**
      * @param array<string, scalar|null> $attributes
      *
@@ -19,7 +24,7 @@ final class AttributeNormaliser
      *
      * @psalm-suppress MixedAssignment
      */
-    public static function normalise(array $attributes, AttributeInformation $info): array
+    public function normalise(array $attributes, AttributeInformation $info): array
     {
         /** @psalm-var array<non-empty-lowercase-string, mixed> $attributes */
         $attributes = array_change_key_case($attributes, CASE_LOWER);
@@ -27,7 +32,7 @@ final class AttributeNormaliser
         $result = [];
 
         foreach ($attributes as $name => $value) {
-            if ($info::isBoolean($name)) {
+            if ($info::isBoolean($name) || is_bool($value)) {
                 if ($value === false) {
                     continue;
                 }
@@ -36,7 +41,7 @@ final class AttributeNormaliser
                 continue;
             }
 
-            if (! $info::exists($name)) {
+            if (! $this->permitUnknownAttributes && ! $info::exists($name)) {
                 continue;
             }
 

--- a/src/HTML/AttributeNormaliserFactory.php
+++ b/src/HTML/AttributeNormaliserFactory.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Looker\HTML;
+
+use Psr\Container\ContainerInterface;
+
+use function Psl\Type\bool;
+use function Psl\Type\optional;
+use function Psl\Type\shape;
+
+/** @psalm-internal Looker */
+final readonly class AttributeNormaliserFactory
+{
+    public function __invoke(ContainerInterface $container): AttributeNormaliser
+    {
+        $config = optional(shape([
+            'looker' => optional(shape([
+                'permitUnknownAttributes' => optional(bool()),
+            ], true)),
+        ], true))->assert(
+            $container->has('config')
+                ? $container->get('config')
+                : [],
+        );
+
+        return new AttributeNormaliser(
+            $config['looker']['permitUnknownAttributes'] ?? true,
+        );
+    }
+}

--- a/src/Plugin/Factory/HeadLinkFactory.php
+++ b/src/Plugin/Factory/HeadLinkFactory.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Looker\Plugin\Factory;
 
+use Looker\HTML\AttributeNormaliser;
 use Looker\Plugin\HeadLink;
 use Looker\Plugin\HtmlAttributes;
 use Looker\PluginManager;
@@ -18,6 +19,7 @@ final class HeadLinkFactory
         return new HeadLink(
             DefaultDoctype::retrieve($container),
             $plugins->get(HtmlAttributes::class),
+            $container->get(AttributeNormaliser::class),
         );
     }
 }

--- a/src/Plugin/Factory/HeadMetaFactory.php
+++ b/src/Plugin/Factory/HeadMetaFactory.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Looker\Plugin\Factory;
 
+use Looker\HTML\AttributeNormaliser;
 use Looker\Plugin\HeadMeta;
 use Looker\Plugin\HtmlAttributes;
 use Looker\PluginManager;
@@ -18,6 +19,7 @@ final class HeadMetaFactory
         return new HeadMeta(
             DefaultDoctype::retrieve($container),
             $plugins->get(HtmlAttributes::class),
+            $container->get(AttributeNormaliser::class),
         );
     }
 }

--- a/src/Plugin/Factory/HeadStyleFactory.php
+++ b/src/Plugin/Factory/HeadStyleFactory.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Looker\Plugin\Factory;
 
+use Looker\HTML\AttributeNormaliser;
 use Looker\Plugin\HeadStyle;
 use Looker\Plugin\HtmlAttributes;
 use Looker\PluginManager;
@@ -17,6 +18,7 @@ final class HeadStyleFactory
 
         return new HeadStyle(
             $plugins->get(HtmlAttributes::class),
+            $container->get(AttributeNormaliser::class),
         );
     }
 }

--- a/src/Plugin/Factory/JavascriptFactory.php
+++ b/src/Plugin/Factory/JavascriptFactory.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Looker\Plugin\Factory;
 
+use Looker\HTML\AttributeNormaliser;
 use Looker\Plugin\HtmlAttributes;
 use Looker\Plugin\Javascript;
 use Looker\PluginManager;
@@ -17,6 +18,7 @@ final class JavascriptFactory
 
         return new Javascript(
             $plugins->get(HtmlAttributes::class),
+            $container->get(AttributeNormaliser::class),
         );
     }
 }

--- a/src/Plugin/HeadLink.php
+++ b/src/Plugin/HeadLink.php
@@ -29,6 +29,7 @@ final class HeadLink implements StatefulPlugin, Stringable
     public function __construct(
         private readonly Doctype $doctype,
         private readonly HtmlAttributes $attributeHelper,
+        private readonly AttributeNormaliser $attributeNormaliser,
         private readonly string $defaultSeparator = "\n\t",
     ) {
         $this->separator = $this->defaultSeparator;
@@ -129,7 +130,7 @@ final class HeadLink implements StatefulPlugin, Stringable
 
     private function tagToString(Tag $tag): string
     {
-        $attributes = AttributeNormaliser::normalise($tag->attributes, new LinkAttribute());
+        $attributes = $this->attributeNormaliser->normalise($tag->attributes, new LinkAttribute());
 
         return sprintf(
             '<%s %s%s>',

--- a/src/Plugin/HeadMeta.php
+++ b/src/Plugin/HeadMeta.php
@@ -27,6 +27,7 @@ final class HeadMeta implements StatefulPlugin, Stringable
     public function __construct(
         private readonly Doctype $doctype,
         private readonly HtmlAttributes $attributePlugin,
+        private readonly AttributeNormaliser $attributeNormaliser,
         private readonly string $defaultSeparator = "\n\t",
     ) {
         $this->separator = $this->defaultSeparator;
@@ -91,7 +92,7 @@ final class HeadMeta implements StatefulPlugin, Stringable
     /** @param array<non-empty-string, scalar> $attributes */
     private function makeTag(array $attributes): Tag
     {
-        return new Tag('meta', AttributeNormaliser::normalise(
+        return new Tag('meta', $this->attributeNormaliser->normalise(
             $attributes,
             new MetaAttribute(),
         ), null);

--- a/src/Plugin/HeadStyle.php
+++ b/src/Plugin/HeadStyle.php
@@ -25,6 +25,7 @@ final class HeadStyle implements StatefulPlugin, Stringable
 
     public function __construct(
         private readonly HtmlAttributes $attributePlugin,
+        private readonly AttributeNormaliser $attributeNormaliser,
         private readonly string $defaultSeparator = "\n\t",
     ) {
         $this->separator = $this->defaultSeparator;
@@ -80,7 +81,7 @@ final class HeadStyle implements StatefulPlugin, Stringable
     {
         return new Tag(
             'style',
-            AttributeNormaliser::normalise($attributes, new StyleAttribute()),
+            $this->attributeNormaliser->normalise($attributes, new StyleAttribute()),
             $styles,
         );
     }

--- a/src/Plugin/Javascript.php
+++ b/src/Plugin/Javascript.php
@@ -25,6 +25,7 @@ final class Javascript implements StatefulPlugin, Stringable
 
     public function __construct(
         private readonly HtmlAttributes $attributePlugin,
+        private readonly AttributeNormaliser $attributeNormaliser,
         private readonly string $defaultSeparator = "\n\t",
     ) {
         $this->separator = $this->defaultSeparator;
@@ -116,7 +117,7 @@ final class Javascript implements StatefulPlugin, Stringable
     {
         return new Tag(
             'script',
-            AttributeNormaliser::normalise($attributes, new ScriptAttribute()),
+            $this->attributeNormaliser->normalise($attributes, new ScriptAttribute()),
             $script,
         );
     }

--- a/test/HTML/AttributeNormaliserTest.php
+++ b/test/HTML/AttributeNormaliserTest.php
@@ -6,15 +6,24 @@ namespace Looker\Test\HTML;
 
 use Looker\HTML\AttributeNormaliser;
 use Looker\HTML\GlobalAttribute;
+use Override;
 use PHPUnit\Framework\TestCase;
 
 final class AttributeNormaliserTest extends TestCase
 {
+    private AttributeNormaliser $normaliser;
+
+    #[Override]
+    protected function setUp(): void
+    {
+        $this->normaliser = new AttributeNormaliser(true);
+    }
+
     public function testThatAttributeKeysAreLowerCased(): void
     {
         self::assertSame(
             ['accesskey' => 'a'],
-            AttributeNormaliser::normalise(['AccessKey' => 'a'], new GlobalAttribute()),
+            $this->normaliser->normalise(['AccessKey' => 'a'], new GlobalAttribute()),
         );
     }
 
@@ -22,7 +31,7 @@ final class AttributeNormaliserTest extends TestCase
     {
         self::assertSame(
             [],
-            AttributeNormaliser::normalise(['autofocus' => false], new GlobalAttribute()),
+            $this->normaliser->normalise(['autofocus' => false], new GlobalAttribute()),
         );
     }
 
@@ -30,15 +39,41 @@ final class AttributeNormaliserTest extends TestCase
     {
         self::assertSame(
             ['autofocus' => true],
-            AttributeNormaliser::normalise(['autofocus' => 1], new GlobalAttribute()),
+            $this->normaliser->normalise(['autofocus' => 1], new GlobalAttribute()),
         );
     }
 
-    public function testInvalidAttributesAreOmitted(): void
+    public function testThatUnknownBooleansAreSkippedWhenFalse(): void
     {
         self::assertSame(
             [],
-            AttributeNormaliser::normalise(['muppets' => 'foo'], new GlobalAttribute()),
+            $this->normaliser->normalise(['fred' => false], new GlobalAttribute()),
+        );
+    }
+
+    public function testThatUnknownBooleansAreNotSkippedWhenTrue(): void
+    {
+        self::assertSame(
+            ['fred' => true],
+            $this->normaliser->normalise(['fred' => true], new GlobalAttribute()),
+        );
+    }
+
+    public function testInvalidAttributesAreIncludedByDefault(): void
+    {
+        self::assertSame(
+            ['muppets' => 'foo'],
+            $this->normaliser->normalise(['muppets' => 'foo'], new GlobalAttribute()),
+        );
+    }
+
+    public function testInvalidAttributesAreFilteredOutWhenDesired(): void
+    {
+        $normaliser = new AttributeNormaliser(false);
+
+        self::assertSame(
+            [],
+            $normaliser->normalise(['muppets' => 'foo'], new GlobalAttribute()),
         );
     }
 
@@ -55,7 +90,7 @@ final class AttributeNormaliserTest extends TestCase
 
         self::assertSame(
             $expect,
-            AttributeNormaliser::normalise($attributes, new GlobalAttribute()),
+            $this->normaliser->normalise($attributes, new GlobalAttribute()),
         );
     }
 }

--- a/test/Plugin/Factory/HeadLinkFactoryTest.php
+++ b/test/Plugin/Factory/HeadLinkFactoryTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Looker\Test\Plugin\Factory;
 
 use Laminas\Escaper\Escaper;
+use Looker\HTML\AttributeNormaliser;
 use Looker\Plugin\Factory\HeadLinkFactory;
 use Looker\Plugin\HeadLink;
 use Looker\Plugin\HtmlAttributes;
@@ -29,6 +30,7 @@ final class HeadLinkFactoryTest extends TestCase
     {
         $plugin = (new HeadLinkFactory())(new InMemoryContainer([
             PluginManager::class => $this->plugins,
+            AttributeNormaliser::class => new AttributeNormaliser(true),
         ]));
         self::assertInstanceOf(HeadLink::class, $plugin);
     }
@@ -38,6 +40,7 @@ final class HeadLinkFactoryTest extends TestCase
         $plugin = (new HeadLinkFactory())(new InMemoryContainer([
             Escaper::class => new Escaper(),
             PluginManager::class => $this->plugins,
+            AttributeNormaliser::class => new AttributeNormaliser(true),
         ]));
         self::assertInstanceOf(HeadLink::class, $plugin);
     }

--- a/test/Plugin/Factory/HeadMetaFactoryTest.php
+++ b/test/Plugin/Factory/HeadMetaFactoryTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Looker\Test\Plugin\Factory;
 
 use Laminas\Escaper\Escaper;
+use Looker\HTML\AttributeNormaliser;
 use Looker\Plugin\Factory\HeadMetaFactory;
 use Looker\Plugin\HeadMeta;
 use Looker\Plugin\HtmlAttributes;
@@ -29,6 +30,7 @@ final class HeadMetaFactoryTest extends TestCase
     {
         $plugin = (new HeadMetaFactory())(new InMemoryContainer([
             PluginManager::class => $this->plugins,
+            AttributeNormaliser::class => new AttributeNormaliser(true),
         ]));
         self::assertInstanceOf(HeadMeta::class, $plugin);
     }

--- a/test/Plugin/Factory/HeadStyleFactoryTest.php
+++ b/test/Plugin/Factory/HeadStyleFactoryTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Looker\Test\Plugin\Factory;
 
 use Laminas\Escaper\Escaper;
+use Looker\HTML\AttributeNormaliser;
 use Looker\Plugin\Factory\HeadStyleFactory;
 use Looker\Plugin\HeadStyle;
 use Looker\Plugin\HtmlAttributes;
@@ -29,6 +30,7 @@ final class HeadStyleFactoryTest extends TestCase
     {
         $plugin = (new HeadStyleFactory())(new InMemoryContainer([
             PluginManager::class => $this->plugins,
+            AttributeNormaliser::class => new AttributeNormaliser(true),
         ]));
         self::assertInstanceOf(HeadStyle::class, $plugin);
     }

--- a/test/Plugin/Factory/JavascriptFactoryTest.php
+++ b/test/Plugin/Factory/JavascriptFactoryTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Looker\Test\Plugin\Factory;
 
 use Laminas\Escaper\Escaper;
+use Looker\HTML\AttributeNormaliser;
 use Looker\Plugin\Factory\JavascriptFactory;
 use Looker\Plugin\HtmlAttributes;
 use Looker\Plugin\Javascript;
@@ -20,6 +21,7 @@ final class JavascriptFactoryTest extends TestCase
             PluginManager::class => new InMemoryContainer([
                 HtmlAttributes::class => new HtmlAttributes(new Escaper()),
             ]),
+            AttributeNormaliser::class => new AttributeNormaliser(true),
         ]));
         self::assertInstanceOf(Javascript::class, $plugin);
     }

--- a/test/Plugin/HeadLinkTest.php
+++ b/test/Plugin/HeadLinkTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Looker\Test\Plugin;
 
 use Laminas\Escaper\Escaper;
+use Looker\HTML\AttributeNormaliser;
 use Looker\Plugin\HeadLink;
 use Looker\Plugin\HtmlAttributes;
 use Looker\Value\Doctype;
@@ -21,6 +22,7 @@ final class HeadLinkTest extends TestCase
         $this->plugin = new HeadLink(
             Doctype::HTML5,
             new HtmlAttributes(new Escaper()),
+            new AttributeNormaliser(true),
             "\n",
         );
     }
@@ -109,11 +111,11 @@ final class HeadLinkTest extends TestCase
         self::assertSame($expect, $this->plugin->toString());
     }
 
-    public function testThatUnknownAttributesAreSkipped(): void
+    public function testThatUnknownAttributesAreNotSkipped(): void
     {
         $this->plugin->append('stylesheet', 'foo', ['unknown' => 'whatever']);
 
-        $expect = '<link href="foo" rel="stylesheet">';
+        $expect = '<link href="foo" rel="stylesheet" unknown="whatever">';
 
         self::assertSame($expect, $this->plugin->toString());
     }
@@ -165,6 +167,7 @@ final class HeadLinkTest extends TestCase
         $plugin = new HeadLink(
             Doctype::XHTML1Strict,
             new HtmlAttributes(new Escaper()),
+            new AttributeNormaliser(true),
             "\n",
         );
 

--- a/test/Plugin/HeadMetaTest.php
+++ b/test/Plugin/HeadMetaTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Looker\Test\Plugin;
 
 use Laminas\Escaper\Escaper;
+use Looker\HTML\AttributeNormaliser;
 use Looker\Plugin\HeadMeta;
 use Looker\Plugin\HtmlAttributes;
 use Looker\Value\Doctype;
@@ -24,6 +25,7 @@ final class HeadMetaTest extends TestCase
         $this->plugin = new HeadMeta(
             Doctype::HTML5,
             new HtmlAttributes(new Escaper()),
+            new AttributeNormaliser(true),
             PHP_EOL,
         );
     }
@@ -83,14 +85,19 @@ final class HeadMetaTest extends TestCase
 
     public function testXHTMLDocumentsWillHaveSelfClosingTag(): void
     {
-        $plugin = new HeadMeta(Doctype::XHTML1Strict, new HtmlAttributes(new Escaper()), PHP_EOL);
+        $plugin = new HeadMeta(
+            Doctype::XHTML1Strict,
+            new HtmlAttributes(new Escaper()),
+            new AttributeNormaliser(true),
+            PHP_EOL,
+        );
         $plugin->append(['name' => 'foo', 'content' => 'bar']);
         self::assertSame('<meta content="bar" name="foo" />', $plugin->toString());
     }
 
     public function testThatEmptyAttributesYieldEmptyString(): void
     {
-        $this->plugin->append(['foo' => 'bar']);
+        $this->plugin->append([]);
         self::assertSame('', $this->plugin->toString());
     }
 

--- a/test/Plugin/HeadStyleTest.php
+++ b/test/Plugin/HeadStyleTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Looker\Test\Plugin;
 
 use Laminas\Escaper\Escaper;
+use Looker\HTML\AttributeNormaliser;
 use Looker\Plugin\HeadStyle;
 use Looker\Plugin\HtmlAttributes;
 use Override;
@@ -19,6 +20,7 @@ final class HeadStyleTest extends TestCase
     {
         $this->plugin = new HeadStyle(
             new HtmlAttributes(new Escaper()),
+            new AttributeNormaliser(true),
             "\n",
         );
     }
@@ -149,12 +151,12 @@ final class HeadStyleTest extends TestCase
         );
     }
 
-    public function testThatUnknownAttributesAreOmitted(): void
+    public function testThatUnknownAttributesAreNotOmitted(): void
     {
         $this->plugin->append('p { color: pink; }', ['goats' => 'are great']);
 
         $expect = <<<'HTML'
-            <style>
+            <style goats="are&#x20;great">
             p { color: pink; }
             </style>
             HTML;

--- a/test/Plugin/JavascriptTest.php
+++ b/test/Plugin/JavascriptTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Looker\Test\Plugin;
 
 use Laminas\Escaper\Escaper;
+use Looker\HTML\AttributeNormaliser;
 use Looker\Plugin\HtmlAttributes;
 use Looker\Plugin\Javascript;
 use Override;
@@ -19,6 +20,7 @@ final class JavascriptTest extends TestCase
     {
         $this->plugin = new Javascript(
             new HtmlAttributes(new Escaper()),
+            new AttributeNormaliser(true),
             "\n",
         );
     }
@@ -107,12 +109,12 @@ final class JavascriptTest extends TestCase
         );
     }
 
-    public function testThatUnknownAttributesAreOmitted(): void
+    public function testThatUnknownAttributesAreNotOmitted(): void
     {
         $this->plugin->appendFile('one.js', ['goats' => 'are great']);
 
         self::assertSame(
-            '<script src="one.js"></script>',
+            '<script goats="are&#x20;great" src="one.js"></script>',
             $this->plugin->toString(),
         );
     }


### PR DESCRIPTION
In order to permit arbitrary attributes on elements, the normaliser must be configurable, so it now accepts a boolean to its constructor _(that defaults to `true`)_ to configure this behaviour.

The main config array specifies `looker.permitUnknownAttributes` and `AttributeNormaliser::normalise()` is now an instance method instead of a static method.

All relevant plugin constructors are updated to accommodate injection of the normaliser service.